### PR TITLE
Fixed crashes in cdi4dc and mds4dc (mds4dc is still borked in docker, at least on arm64)

### DIFF
--- a/cdi4dc/src/cdidata.c
+++ b/cdi4dc/src/cdidata.c
@@ -11,6 +11,9 @@
 */
 
 #include "cdibuild.h"
+#include "tools.h"
+
+void write_gap_end_tracks(FILE *cdi);
 
 void write_data_gap_start_track(FILE* cdi) {
 	int i;

--- a/cdi4dc/src/main.c
+++ b/cdi4dc/src/main.c
@@ -89,7 +89,7 @@ void print_head() {
 }
 
 void create_audio_data_image(FILE* infp, FILE* outfp, char* outfilename) {
-	char volume_name[32];
+	char volume_name[33];
     int data_blocks_count;
 	float space_used;
 
@@ -144,7 +144,7 @@ void create_audio_data_image(FILE* infp, FILE* outfp, char* outfilename) {
 }
 
 void create_data_data_image(FILE* infp, FILE* outfp, char* outfilename) {
-	char volume_name[32];
+	char volume_name[33];
 	int data_blocks_count;
 	float space_used;
 

--- a/cdi4dc/src/main.c
+++ b/cdi4dc/src/main.c
@@ -29,8 +29,8 @@
 #include <console.h>
 #include <stdlib.h>
 
-#define BUILD_DATE "13 april 2007"
-#define VERSION "0.4b"
+#define BUILD_DATE "14 march 2021"
+#define VERSION "0.5b"
 #define WARNING_MSG "(TO A CD-RW PLEASE AGAIN... BETA VERSION !!!)"
 
 uint32_t x, y; // position ou on doit placer le curseur avant d'écrire le pourcentage

--- a/mds4dc/inc/config.h
+++ b/mds4dc/inc/config.h
@@ -5,10 +5,10 @@
 #define APP_CONSOLE
 
 // version
-#define VERSION "0.1b"
+#define VERSION "0.2b"
 
 // date de création
-#define DATE "06/06/07"
+#define DATE "14/03/21"
 
 // pour bien aligner chaque info
 #define INFO_MSG_SIZE 25

--- a/mds4dc/inc/mdsaudio.h
+++ b/mds4dc/inc/mdsaudio.h
@@ -10,6 +10,22 @@
 #ifndef __MDSAUDIO__H__
 #define __MDSAUDIO__H__
 
+void ad_write_mds_header(FILE* mds);
+void ad_write_cdda_session_infos(FILE* mds, int cdda_session_sectors_count, int cdda_tracks_count, int data_session_sectors_count);
+void ad_write_cdda_lead_in_track_first_infos(FILE* mds);
+void ad_write_cdda_lead_in_track_last_infos(FILE* mds, int cdda_tracks_count);
+void ad_write_cdda_lead_in_track_leadout_infos(FILE* mds, int cdda_session_sectors_count);
+void ad_write_cdda_track_infos(FILE* mds, int track_num, int cdda_tracks_count, int msinfo);
+void ad_write_data_session_infos(FILE* mds, int cdda_session_sectors_count);
+void ad_write_data_lead_in_track_first_infos(FILE* mds, int cdda_tracks_count);
+void ad_write_data_lead_in_track_last_infos(FILE* mds, int cdda_tracks_count);
+void ad_write_data_lead_in_track_leadout_infos(FILE* mds, int cdda_session_sectors_count, int data_session_sectors_count);
+void ad_write_data_track_infos(FILE* mds, int cdda_session_sectors_count, int cdda_tracks_count);
+void ad_write_data_track_infos_header_start(FILE* mds);
+void ad_write_cdda_track_sectors_count(FILE* mds, unsigned int cdda_sectors_count);
+void ad_write_data_track_sectors_count(FILE* mds, unsigned int data_session_sectors_count);
+void ad_write_mds_footer(FILE* mds, int cdda_tracks_count);
+
 /*
 	Structure d'un "MDS" AUDIO / DATA:
 	

--- a/mds4dc/inc/mdsdata.h
+++ b/mds4dc/inc/mdsdata.h
@@ -10,6 +10,20 @@
 #ifndef __MDSDATA__H__
 #define __MDSDATA__H__
 
+void dd_write_mds_header(FILE* mds);
+void dd_write_data_session_infos(FILE* mds, int data_session_sectors_count, int boot_session_sectors_count);
+void dd_write_data_lead_in_track_first_infos(FILE* mds);
+void dd_write_data_lead_in_track_last_infos(FILE* mds);
+void dd_write_data_lead_in_track_leadout_infos(FILE* mds, int data_session_sectors_count);
+void dd_write_data_track_infos(FILE* mds);
+void dd_write_boot_session_infos(FILE* mds, int data_session_sectors_count, int boot_session_sectors_count);
+void dd_write_boot_lead_in_track_first_infos(FILE* mds);
+void dd_write_boot_lead_in_track_last_infos(FILE* mds);
+void dd_write_boot_lead_in_track_leadout_infos(FILE* mds, int data_session_sectors_count, int boot_session_sectors_count);
+void dd_write_boot_track_infos(FILE* mds, int data_session_sectors_count);
+void dd_write_boot_track_infos_header(FILE* mds, int data_session_sectors_count);
+void dd_write_mds_footer(FILE* mds);
+
 /* Header */
 
 #define DD_MDS_HEADER_ENTRIES 25

--- a/mds4dc/src/console.c
+++ b/mds4dc/src/console.c
@@ -60,9 +60,11 @@ void gotoXY(uint32_t x, uint32_t y) {
 }
 
 uint32_t whereX() {
+    return 0;
 }
 
 uint32_t whereY() {
+    return 0;
 }
 
 #endif

--- a/mds4dc/src/imgwrite.c
+++ b/mds4dc/src/imgwrite.c
@@ -1,9 +1,15 @@
 #include <stdio.h>
 #include "imgwrite.h"
 #include "mdsaudio.h"
+#include "mdsdata.h"
 #include "mdfwrt.h"
 #include "tools.h"
 #include "config.h"
+
+void warning_msg(char* msg);
+void info_msg(char* msg);
+void start_progressbar();
+void writing_track_event_end(uint32_t block_count, uint32_t track_size);
 
 extern unsigned int image_format;
 extern int image_creation_okay;
@@ -238,7 +244,7 @@ void write_data_data_image(FILE* mds, FILE* mdf, FILE* iso) {
 		dd_write_boot_lead_in_track_last_infos(mds);
 		dd_write_boot_lead_in_track_leadout_infos(mds, data_session_sectors_count, data_boothead_session_sectors_count);
 		dd_write_boot_track_infos(mds, data_session_sectors_count);
-		dd_write_boot_track_infos_header(mds);
+		dd_write_boot_track_infos_header(mds, data_session_sectors_count);
 		
 		// pied
 		dd_write_mds_footer(mds);

--- a/mds4dc/src/main.c
+++ b/mds4dc/src/main.c
@@ -80,7 +80,7 @@ void warning_msg(char* msg) {
 
 void info_msg(char* msg) {
 	int i;
-    char buf[INFO_MSG_SIZE];
+    char buf[INFO_MSG_SIZE+2];
 	unsigned int len = (INFO_MSG_SIZE - strlen(msg)) - 1; // -1 pour le ":"
 	
 	if (strlen(msg) < INFO_MSG_SIZE) {
@@ -96,23 +96,6 @@ void info_msg(char* msg) {
 		textColor(WHITE);
 		printf(msg);
 		textColor(LIGHT_GRAY);
-	}
-}
-
-void free_all_stuffs() {
-	int i;
-	
-	// destructions des différents buffers de noms.
-	free(output_mds_filename);
-	free(output_mdf_filename);
-	free(data_track_iso_filename);
-	free(proggy_name);
-	
-	// destruction du tableau contenant les pistes CDDA
-	if (image_format == AUDIO_DATA_CUSTOM_CDDA_IMAGE_FORMAT) {
-		for(i = 0 ; i < audio_files_count ; i++)
-			free(audio_files_array[i]);
-		free(audio_files_array);
 	}
 }
 
@@ -132,22 +115,22 @@ void padding_event(int sector_count) {
 void writing_track_event(uint32_t current, uint32_t total) {
 	gotoXY(x, y);
 	
-	float p = (float)current / (float)total;	
-    uint32_t percent = p * 100;
-	printf("[");
-	textColor(LIGHT_RED);
-	printf("%u/%u", current, total);
-	textColor(LIGHT_GRAY);
-	printf("] - ");
-	textColor(LIGHT_MAGENTA);
-	printf("%u%%\n", percent);
-	textColor(LIGHT_GRAY);
+	// float p = (float)current / (float)total;	
+    // uint32_t percent = p * 100;
+	// printf("[");
+	// textColor(LIGHT_RED);
+	// printf("%u/%u", current, total);
+	// textColor(LIGHT_GRAY);
+	// printf("] - ");
+	// textColor(LIGHT_MAGENTA);
+	// printf("%u%%\n", percent);
+	// textColor(LIGHT_GRAY);
 }
 
 void writing_track_event_end(uint32_t block_count, uint32_t track_size) {
 	gotoXY(x, y);
 	
-	char unit[2];
+	char unit[3];
 	float res = (float)track_size;
 	
 	strcpy(unit, get_friendly_unit(&res));
@@ -266,8 +249,6 @@ int main(int argc, char* argv[]) {
 	else if (image_format == DATA_DATA_IMAGE_FORMAT)
 		write_data_data_image(mds, mdf, iso);
 
-	free_all_stuffs();
-	
 	// les fichiers sont fermés dans les différentes fonction de création.
 	
 	int exit_code = 0;

--- a/mds4dc/src/mdfwrt.c
+++ b/mds4dc/src/mdfwrt.c
@@ -3,6 +3,11 @@
 #include "mdsdata.h"
 #include "config.h"
 
+void start_progressbar();
+void writing_track_event(uint32_t current, uint32_t total);
+void writing_track_event_end(uint32_t block_count, uint32_t track_size);
+void padding_event(int sector_count);
+
 extern unsigned int write_method;
 
 // fonction permettant d'écrire une piste audio dans le mdf.

--- a/mds4dc/src/tools.c
+++ b/mds4dc/src/tools.c
@@ -1,4 +1,5 @@
 #include "tools.h"
+#include <ctype.h>
 
 /* 
 	Pour passer un tableau à plusieurs dimensions en paramètre à une fonction, il suffit fournir les différentes 


### PR DESCRIPTION
I was updating my docker containers to be multi-arch (x86_64 and arm64 for the new Apple Silicon ARM Macs and recent Raspberry Pis and other similar single board computers) and I found a crash in cdi4dc due to a stack overflow that was not occurring on x86 platforms for some reason. I fixed that, then I tested mds4dc and realized that it crashed on both x86 and ARM platforms, so I fixed that too.

I'm still getting stack corruption of some kind causing crashes with mds4dc inside an arm64 linux docker container, but it's working fine in arm macOS and intel macOS now at least. I spent some time trying to fix it, but I never use mds and I don't think anyone else really does anymore anyway, so I gave up on it, but at least cdi4dc is working fine now inside arm64 docker which is all I was really after.

Before I could dive into fixing the changes, I also needed to fix some build issues on modern macOS, so those changes are included here too (simple stuff like missing function definitions and imports). I confirmed that everything still builds on Linux as well, though I haven't tested on Windows.

I also incremented the build numbers and build dates for both to reflect the new code changes.

I know this is planned to be rewritten anyway (now that I've taken a dive in the code I can see why haha), but for now these changes resolve some outstanding issues.