### PR TITLE
Fix printf security compilation warning/error

### DIFF
--- a/mds4dc/src/main.c
+++ b/mds4dc/src/main.c
@@ -94,7 +94,7 @@ void info_msg(char* msg) {
 		textColor(LIGHT_GRAY);
 	} else {
 		textColor(WHITE);
-		printf(msg);
+		printf("%s", msg);
 		textColor(LIGHT_GRAY);
 	}
 }


### PR DESCRIPTION
Fix the following GCC compilation error when the `-Wformat-security` and `-Werror=format-security` flags are used:

```
main.c: In function 'info_msg':
main.c:97:3: error: format not a string literal and no format arguments [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wformat-security-Werror=format-security8;;]
   97 |   printf(msg);
      |   ^~~~~~
```