### PR TITLE
Fix build error on non-Linux (or Apple) systems.

### DIFF
--- a/common/src/console.c
+++ b/common/src/console.c
@@ -3,10 +3,10 @@
 #ifndef WIN32
 #include <libgen.h>
 #include <stdlib.h>
-#ifdef __APPLE__
-#include <limits.h>
-#else
+#ifdef __linux__
 #include <linux/limits.h>
+#else
+#include <limits.h>
 #endif
 #define _MAX_FNAME 4096
 #endif


### PR DESCRIPTION
POSIX says `<limits.h>` should provide `PATH_MAX`
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html#tag_13_23_03_02
and `<linux/limits.h>` is Linux specific.

Confirmed on NetBSD/i386 9.3 and ubuntu 22.04.2LTS.